### PR TITLE
Update solvers.md to use comparable solvers

### DIFF
--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -31,14 +31,11 @@ bestfit, fsumm = fit(model, data, cmpfit())
 or
 ```@example abc
 using NonlinearSolve
-bestfit, fsumm = fit(model, data, NewtonRaphson())
+bestfit, fsumm = fit(model, data, LevenbergMarquardt())
 ```
 
-The above solvers typically provide the same results, although in some complex case the results may differ.
-
-!!! warning
-    Unlike LsqFit and CMPFIT, the solvers from [NonlinearSolve](https://docs.sciml.ai/NonlinearSolve/stable/) do not provide best fit parameter uncertainties.
-
+The above solvers typically provide the same results, although in some complex case the results may differ. Generally `lsqfit` is not recommeended
+due to numerical issues in the implementation which cause squaring of the condition number and thus divergence in cases where the Jacobian is ill-conditioned
 
 ## The `cmpfit()` solver
 


### PR DESCRIPTION
NewtonRhapson is not a good choice because there is a near singularity in the Jacobian, so the different methods are relying on using a Gauss-Newton-like representation to handle that effectively. But NonlinearSolve is for some reason hardcoded to Newton, which is pretty much never a good choice for this package, so this shows something that wouldn't be suggested to users. When this is corrected then the example is fine.